### PR TITLE
One-to-may framework names

### DIFF
--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.6.0.8
+version:             0.6.0.9
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.5.0.7
+version:             0.6.0.8
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.6.0.9
+version:             0.6.0.10
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ import           Options.Applicative  as Opts
 
 
 romeVersion :: String
-romeVersion = "0.5.0.7"
+romeVersion = "0.6.0.8"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ import           Options.Applicative  as Opts
 
 
 romeVersion :: String
-romeVersion = "0.6.0.8"
+romeVersion = "0.6.0.9"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ import           Options.Applicative  as Opts
 
 
 romeVersion :: String
-romeVersion = "0.6.0.9"
+romeVersion = "0.6.0.10"
 
 
 

--- a/src/Data/Romefile.hs
+++ b/src/Data/Romefile.hs
@@ -64,4 +64,4 @@ getBucket ini = requireKey s3BucketKey `inRequiredSection` cacheSectionDelimiter
 
 getRomefileEntries ini = do
   m <- inOptionalSection repositoryMapSectionDelimiter M.empty keysAndValues `fromIni''` ini
-  return $ Prelude.map (\(repoName, frameworkCommonNames) -> RomefileEntry (unpack repoName) (Prelude.map unpack (splitOn "," frameworkCommonNames))) (M.toList m)
+  return $ Prelude.map (\(repoName, frameworkCommonNames) -> RomefileEntry (unpack repoName) (Prelude.map (unpack . strip) (splitOn "," frameworkCommonNames))) (M.toList m)

--- a/src/Data/Romefile.hs
+++ b/src/Data/Romefile.hs
@@ -25,7 +25,7 @@ import           Control.Monad.Trans
 type FrameworkName = String
 type GitRepoName   = String
 data RomefileEntry = RomefileEntry { gitRepositoryName   :: GitRepoName
-                                   , frameworkCommonName :: FrameworkName
+                                   , frameworkCommonNames :: [FrameworkName]
                                    }
                                    deriving (Show, Eq)
 
@@ -64,4 +64,4 @@ getBucket ini = requireKey s3BucketKey `inRequiredSection` cacheSectionDelimiter
 
 getRomefileEntries ini = do
   m <- inOptionalSection repositoryMapSectionDelimiter M.empty keysAndValues `fromIni''` ini
-  return $ Prelude.map (\(repoName, frameworkCommonName) -> RomefileEntry (unpack repoName) (unpack frameworkCommonName)) (M.toList m)
+  return $ Prelude.map (\(repoName, frameworkCommonNames) -> RomefileEntry (unpack repoName) (Prelude.map unpack (splitOn "," frameworkCommonNames))) (M.toList m)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -223,7 +223,7 @@ deriveFrameworkNameAndVersion ::  M.Map GitRepoName [FrameworkName] -> CartfileE
 deriveFrameworkNameAndVersion romeMap (CartfileEntry GitHub l v) = map (\n -> (n, v)) $ fromMaybe [gitHubRepositoryName] (M.lookup gitHubRepositoryName romeMap)
   where
     gitHubRepositoryName = last $ splitWithSeparator '/' l
-deriveFrameworkName romeMap (CartfileEntry Git l v)    = map (\n -> (n, v)) $ fromMaybe [gitRepositoryName] (M.lookup gitRepositoryName romeMap)
+deriveFrameworkNameAndVersion romeMap (CartfileEntry Git l v)    = map (\n -> (n, v)) $ fromMaybe [gitRepositoryName] (M.lookup gitRepositoryName romeMap)
   where
     gitRepositoryName = getGitRepositoryNameFromGitURL l
     getGitRepositoryNameFromGitURL = replace ".git" "" . last . splitWithSeparator '/'


### PR DESCRIPTION
Implements #12 

additional frameworks names are specified in the `Romefile` as

```
[RepositoryMap]
CocoaLumberjack = CocoaLumberjack, CocoaLumberjackSwift
```