### PR TITLE
Add tests for filterByName and splitWithSeparator

### DIFF
--- a/Rome.cabal
+++ b/Rome.cabal
@@ -59,10 +59,13 @@ executable rome
 
 test-suite Rome-test
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
-  main-is:             Spec.hs
+  hs-source-dirs:      tests
+  main-is:             Tests.hs
   build-depends:       base
                      , Rome
+                     , QuickCheck >= 2.8.2
+                     , hspec >= 2.2.3
+                     , text >= 1.2
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -10,6 +10,8 @@ module Lib
     ( parseRomeOptions
     , runRomeWithOptions
     , discoverRegion
+    , filterByName
+    , splitWithSeparator
     ) where
 
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,0 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,0 +1,55 @@
+module Main where
+
+import           Lib
+import           Data.Cartfile
+import           Data.Romefile
+import qualified Data.Text as T
+
+import           Test.Hspec
+import           Test.QuickCheck
+
+nonEmptyString :: Gen String
+nonEmptyString = listOf1 arbitrary
+
+instance Arbitrary FrameworkName where
+  arbitrary = FrameworkName <$> nonEmptyString
+
+instance Arbitrary Version where
+  arbitrary = Version <$> nonEmptyString
+
+prop_filter_idempotent :: [(FrameworkName, Version)] -> FrameworkName -> Bool
+prop_filter_idempotent ls n = filterByName ls n == filterByName (filterByName ls n) n
+
+prop_filter_smaller :: [(FrameworkName, Version)] -> FrameworkName -> Bool
+prop_filter_smaller ls n = length (filterByName ls n) <= length ls
+
+prop_filter_model :: [(FrameworkName, Version)] -> FrameworkName -> Bool
+prop_filter_model ls n = map fst (filterByName ls n) == filter (== n) (map fst ls)
+
+prop_split_length :: Char -> String -> Property
+prop_split_length sep ls =
+  not (null ls) ==>
+    length (splitWithSeparator sep ls) == 1 + (length $ filter (== sep) ls)
+
+prop_split_string :: String -> Property
+prop_split_string ls =
+  not (null ls) ==>
+    map T.pack (splitWithSeparator '/' ls) == T.split (=='/') (T.pack ls)
+
+main :: IO ()
+main =
+  do
+    putStrLn "prop_filter_idempotent"
+    quickCheck prop_filter_idempotent
+
+    putStrLn "prop_filter_smaller"
+    quickCheck prop_filter_smaller
+
+    putStrLn "prop_filter_model"
+    quickCheck prop_filter_model
+
+    putStrLn "prop_split_length"
+    quickCheck prop_split_length
+
+    putStrLn "prop_split_string"
+    quickCheck prop_split_string


### PR DESCRIPTION
added some tests for `filterByName` and `splitWithSeparator`.

One problem I found is I had to export the functions to make them visible. Looked into this a bit and found a solution on [stackoverflow](http://stackoverflow.com/questions/14379185/function-privacy-and-unit-testing-haskell/14379426#14379426).

anyway, i'm totally new to `QuickCheck` and this is not quite as beginner as i expected :sweat: