### PR TITLE
Ignoring empty lines in Cartfile.resolved

### DIFF
--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.7.1.13
+version:             0.7.1.14
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ import           Options.Applicative  as Opts
 
 
 romeVersion :: String
-romeVersion = "0.7.1.13"
+romeVersion = "0.7.1.14"
 
 
 

--- a/src/Data/Cartfile.hs
+++ b/src/Data/Cartfile.hs
@@ -64,4 +64,4 @@ parseCartfileResolvedLine = do
   return CartfileEntry {..}
 
 parseCartfileResolved :: String -> IO (Either Parsec.ParseError [CartfileEntry])
-parseCartfileResolved = Parsec.parseFromFile (Parsec.many1 parseCartfileResolvedLine)
+parseCartfileResolved = Parsec.parseFromFile (Parsec.many1 (Parsec.optional Parsec.spaces >> parseCartfileResolvedLine))


### PR DESCRIPTION
- Fixes a bug where entries in the Cartfile.resolved appearing after a new line were ignored ( #40 )
