### PR TITLE
Feature/local cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ The Romefile has three purposes:
 1. Allows to use custom name mappings between repository names and framework names - `[RepositoryMap]` section. This section is __optional__ and can be omitted.
 1. Allows to ignore certain framework names - `[IgnoreMap]` section. This section is __optional__ and can be omitted.
 
-
 A Romefile looks like this:
 
 ```
@@ -157,7 +156,8 @@ This contains the mappings of git repository names and framework names should be
 This is particularly useful in case not all your `Cartfile.resolved` entries produce a framework.
 
 Some repositories use Carthage as a simple mechanism to include other git repositories that do not produce frameworks.
-Even Carthage itself does this, to include xcconfigs.
+Even Carthage itself does this, to include `xcconfigs`.
+
 
 Example:
 
@@ -167,7 +167,9 @@ Suppose you have the following in your `Cartfile`
 github "Quick/Nimble"
 github "jspahrsummers/xcconfigs"
 ```
+
 `xcconfigs` can be ignored by Rome by adding an `IgnoreMap` section in the Romefile
+
 
 ```
 [IgnoreMap]

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This contains the mappings of git repository names and framework names should be
 This is particularly useful in case not all your `Cartfile.resolved` entries produce a framework.
 
 Some repositories use Carthage as a simple mechanism to include other git repositories that do not produce frameworks.
-Even Carthage itself does this, to include `xcconfigs`.
+Even Carthage itself does this, to include xcconfigs.
 
 
 Example:

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ The Romefile is in the [INI format](https://en.wikipedia.org/wiki/INI_file)
 
 #### Cache section
 This section contains the name of:
-- the S3 bucket you want Rome to use to upload/download. (required)
-- the _absolute path_ to local directory to use as an additional cache. (optional)
+- the S3 bucket you want Rome to use to upload/download. The key `S3-Bucket` is __required__.
+- the path to local directory to use as an additional cache. The key `local` is __optional__.
 
 #### RepositoryMap
 This contains the mappings of git repository names with framework names.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ environment variable to your desired profile.
 
 The Romefile has three purposes:
 
-1. Specifies what S3 bucket to use - `[Cache]` section. This section is __required__.
+1. Specifies what caches to use - `[Cache]` section. This section is __required__.
 1. Allows to use custom name mappings between repository names and framework names - `[RepositoryMap]` section. This section is __optional__ and can be omitted.
 1. Allows to ignore certain framework names - `[IgnoreMap]` section. This section is __optional__ and can be omitted.
 
@@ -107,6 +107,7 @@ A Romefile looks like this:
 ```
 [Cache]
   S3-Bucket = ios-dev-bucket
+  local = /tmp/Rome
 
 [RepositoryMap]
   HockeySDK-iOS = HockeySDK
@@ -119,8 +120,10 @@ A Romefile looks like this:
 
 The Romefile is in the [INI format](https://en.wikipedia.org/wiki/INI_file)
 
-#### S3Bucket section
-This section contains the name of the S3 bucket you want Rome to use to upload/download.
+#### Cache section
+This section contains the name of:
+- the S3 bucket you want Rome to use to upload/download. (required)
+- the _absolute path_ to local directory to use as an additional cache. (optional)
 
 #### RepositoryMap
 This contains the mappings of git repository names with framework names.
@@ -234,6 +237,8 @@ Uploaded CatFramework to: CatFramework/CatFramework.framework-3.3.1.zip
 Uploaded CatFramework.dSYM to: CatFramework/CatFramework.framework.dSYM-3.3.1.zip
 ```
 
+If a local cache is specified in your `Romefile` and you wish to ignore it pass `--skip-local-cache` on the command line.
+
 #### Downloading
 
 Downloading one or more frameworks and corresponding dSYMs
@@ -252,6 +257,8 @@ Unzipped CatFramework from: CatFramework.framework-3.3.1.zip
 Downloaded CatFramework from: CatFramework/CatFramework.framework.dSYM-3.3.1.zip
 Unzipped CatFramework from: CatFramework.framework.dSYM-3.3.1.zip
 ```
+
+If a local cache is specified in your `Romefile` and you wish to ignore it pass `--skip-local-cache` on the command line.
 
 #### Listing
 

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.7.1.14
+version:             0.8.0.15
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome
@@ -29,12 +29,15 @@ library
                        , mtl >= 2.2.1
                        , MissingH >= 1.3
                        , directory >= 1.2.2
+                       , filepath >= 1.4
                        , containers >= 0.5
                        , unordered-containers >= 0.2.7
+                       , conduit >= 1.2
                        , conduit-extra >= 1.1
                        , ini >= 0.3.5
                        , text >= 1.2
                        , time >= 1.5.0
+                       , transformers >= 0.4
                        , bytestring >= 0.10
                        , zip-archive >= 0.2
                        , resourcet >= 1.1

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.8.0.15
+version:             0.8.0.16
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.8.0.16
+version:             0.8.0.17
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,8 @@ import           Options.Applicative  as Opts
 
 
 romeVersion :: String
-romeVersion = "0.7.1.14"
+romeVersion = "0.8.0.15"
+
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ import           Options.Applicative  as Opts
 
 
 romeVersion :: String
-romeVersion = "0.8.0.15"
+romeVersion = "0.8.0.16"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ import           Options.Applicative  as Opts
 
 
 romeVersion :: String
-romeVersion = "0.8.0.16"
+romeVersion = "0.8.0.17"
 
 
 


### PR DESCRIPTION
Implements support for a local cache as of #38 ~without`--skip-local-cache`for now~.

A local cache is specified by adding the key-value pair `local = /Users/blender/Desktop/rome` in the `[Cache]` section of a Romefile.

When uploading a framework or dSYM they both are also copied to the local cache.
When downloading a framework or a dSYM the local cache is used. If the framework or dSYM does not exist in the local cache the it's fetched from remote.