### PR TITLE
Feature/multiple platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Rome binary is also attached as a zip to each release on the [releases page]
 
 ## The problem
 
-Suppose you're working a number of frameworks for you iOS project and want to
+Suppose you're working a number of frameworks for your project and want to
 share those with your team. A great way to do so is to use Carthage and
 have team members point the `Cartfile` to the new framework version (or branch, tag, commit)
 and run `carthage update`.

--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ Available options:
 
 Available commands:
   upload                   Uploads frameworks and dSYMs contained in the local
-                           Carthage/Build/iOS to S3, according to the local
-                           Cartfile.resolved
-  download                 Downloads and unpacks in Carthage/Build/iOS
+                           Carthage/Build/<platform> to S3, according to the
+                           local Cartfile.resolved
+  download                 Downloads and unpacks in Carthage/Build/<platform>
                            frameworks and dSYMs found in S3, according to the
                            local Carftfile.resolved
   list                     Lists frameworks in the cache and reports cache
@@ -235,11 +235,21 @@ Uploading one or more frameworks and corresponding dSYMs
 Referring to the `Cartfile.resolved` in [RepositoryMap](#repositorymap)
 
 ```
-$ rome upload HockeySDK-iOS awesome-framework-for-cat-names
-Uploaded HockeySDK to: bitstadium/HockeySDK.framework-3.8.6.zip
-Uploaded HockeySDK.dSYM to: bitstadium/HockeySDK.framework.dSYM-3.8.6.zip
-Uploaded CatFramework to: CatFramework/CatFramework.framework-3.3.1.zip
-Uploaded CatFramework.dSYM to: CatFramework/CatFramework.framework.dSYM-3.3.1.zip
+$ rome upload Alamofire
+Uploaded Alamofire to: Alamofire/iOS/Alamofire.framework-4.3.0.zip
+Uploaded Alamofire.dSYM to: Alamofire/iOS/Alamofire.framework.dSYM-4.3.0.zip
+Uploaded Alamofire to: Alamofire/tvOS/Alamofire.framework-4.3.0.zip
+Uploaded Alamofire.dSYM to: Alamofire/tvOS/Alamofire.framework.dSYM-4.3.0.zip
+Uploaded Alamofire to: Alamofire/watchOS/Alamofire.framework-4.3.0.zip
+Uploaded Alamofire.dSYM to: Alamofire/watchOS/Alamofire.framework.dSYM-4.3.0.zip
+```
+
+Uploading for a specific platform (all platforms are uploaded by default):
+
+```
+$ rome upload --platform ios Alamofire
+Uploaded Alamofire to: Alamofire/iOS/Alamofire.framework-4.3.0.zip
+Uploaded Alamofire.dSYM to: Alamofire/iOS/Alamofire.framework.dSYM-4.3.0.zip
 ```
 
 If a local cache is specified in your `Romefile` and you wish to ignore it pass `--skip-local-cache` on the command line.
@@ -252,15 +262,25 @@ Downloading one or more frameworks and corresponding dSYMs
 Referring to the `Cartfile.resolved` in [RepositoryMap](#repositorymap)
 
 ```
-$ rome download HockeySDK-iOS awesome-framework-for-cat-names
-Downloaded HockeySDK from: HockeySDK/HockeySDK.framework-3.8.6.zip
-Unzipped HockeySDK from: HockeySDK.framework-3.8.6.zip
-Downloaded HockeySDK.dSYM from: HockeySDK/HockeySDK.framework.dSYM-3.8.6.zip
-Unzipped HockeySDK.dSYM from: HockeySDK.framework.dSYM-3.8.6.zip
-Downloaded CatFramework from: CatFramework/CatFramework.framework-3.3.1.zip
-Unzipped CatFramework from: CatFramework.framework-3.3.1.zip
-Downloaded CatFramework from: CatFramework/CatFramework.framework.dSYM-3.3.1.zip
-Unzipped CatFramework from: CatFramework.framework.dSYM-3.3.1.zip
+$ rome download Alamofire
+Downloaded Alamofire from: Alamofire/iOS/Alamofire.framework-4.3.0.zip
+Downloaded Alamofire.dSYM from: Alamofire/iOS/Alamofire.framework.dSYM-4.3.0.zip
+Error downloading Alamofire : The specified key does not exist.
+Error downloading Alamofire.dSYM : The specified key does not exist.
+Downloaded Alamofire from: Alamofire/tvOS/Alamofire.framework-4.3.0.zip
+Downloaded Alamofire.dSYM from: Alamofire/tvOS/Alamofire.framework.dSYM-4.3.0.zip
+Downloaded Alamofire from: Alamofire/watchOS/Alamofire.framework-4.3.0.zip
+Downloaded Alamofire.dSYM from: Alamofire/watchOS/Alamofire.framework.dSYM-4.3.0.zip
+```
+
+Downloading for a specific platform (all platforms are downloaded by default):
+
+```
+$ rome download --platform ios,watchos Alamofire
+Downloaded Alamofire from: Alamofire/iOS/Alamofire.framework-4.3.0.zip
+Downloaded Alamofire.dSYM from: Alamofire/iOS/Alamofire.framework.dSYM-4.3.0.zip
+Downloaded Alamofire from: Alamofire/watchOS/Alamofire.framework-4.3.0.zip
+Downloaded Alamofire.dSYM from: Alamofire/watchOS/Alamofire.framework.dSYM-4.3.0.zip
 ```
 
 If a local cache is specified in your `Romefile` and you wish to ignore it pass `--skip-local-cache` on the command line.
@@ -268,34 +288,41 @@ If a local cache is specified in your `Romefile` and you wish to ignore it pass 
 #### Listing
 
 Listing frameworks and reporting on their availability:
+
 ```
 $ rome list
-Alamofire 3.4.1 ✔︎
-GCDKit 1.2.5 ✔︎
-HanekeSwift v0.10.1 ✔︎
-HockeySDK-iOS 3.8.6 ✔︎
-KeychainAccess v2.3.6 ✔︎
-M13Checkbox 2.1.2 ✔︎
-ResearchKit 1.3.1 ✘
+Alamofire 4.3.0 : +iOS -macOS +tvOS +watchOS
+ResearchKit 1.4.1 : +iOS -macOS -tvOS -watchOS
 ```
 
 Listing only frameworks present in the cache:
 
 ```
 $ rome list --present
-Alamofire
-GCDKit
-HanekeSwift
-HockeySDK-iOS
-KeychainAccess
-M13Checkbox
+Alamofire 4.3.0 : +iOS +tvOS +watchOS
+ResearchKit 1.4.1 : +iOS
 ```
 
 Listing only frameworks missing from the cache:
 
 ```
 $ rome list --missing
-ResearchKit
+Alamofire 4.3.0 : -macOS
+ResearchKit 1.4.1 : -macOS -tvOS -watchOS
+```
+
+Listing frameworks missing for specific platforms:
+
+```
+$ rome list --missing --platform watchos,tvos
+ResearchKit 1.4.1 : -tvOS -watchOS
+```
+
+Forwarding a list of missing frameworks to Carthage for building:
+
+```
+$ rome list --missing --platform ios | awk '{print $1}' | xargs carthage build --platform ios
+*** xcodebuild output can be found in ...
 ```
 
 Note: `list` __completely ignores dSYMs__. If a dSYM is missing the corresponding

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Lib
                        , Data.Cartfile
+                       , Data.GitRepoAvailability
                        , Data.Romefile
                        , Data.TargetPlatform
                        , Data.Ini.Utils

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.8.0.17
+version:             0.9.0.18
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome
@@ -18,6 +18,7 @@ library
   exposed-modules:     Lib
                        , Data.Cartfile
                        , Data.Romefile
+                       , Data.TargetPlatform
                        , Data.Ini.Utils
                        , Text.Parsec.Utils
 
@@ -35,6 +36,7 @@ library
                        , conduit >= 1.2
                        , conduit-extra >= 1.1
                        , ini >= 0.3.5
+                       , split >= 0.2.1.3
                        , text >= 1.2
                        , time >= 1.5.0
                        , transformers >= 0.4

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -37,7 +37,6 @@ library
                        , conduit >= 1.2
                        , conduit-extra >= 1.1
                        , ini >= 0.3.5
-                       , split >= 0.2.1.3
                        , text >= 1.2
                        , time >= 1.5.0
                        , transformers >= 0.4

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -37,6 +37,7 @@ library
                        , conduit >= 1.2
                        , conduit-extra >= 1.1
                        , ini >= 0.3.5
+                       , split >= 0.2.1.3
                        , text >= 1.2
                        , time >= 1.5.0
                        , transformers >= 0.4

--- a/src/Data/GitRepoAvailability.hs
+++ b/src/Data/GitRepoAvailability.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Data.GitRepoAvailability
+    ( GitRepoAvailability (..)
+    , FrameworkAvailability (..)
+    , FrameworkVersion (..)
+    , PlatformAvailability (..)
+    ) where
+
+import Data.Cartfile
+import Data.Romefile
+import Data.TargetPlatform
+
+data GitRepoAvailability = GitRepoAvailability { _availabilityRepo           :: GitRepoName
+                                               , _availabilityVersion        :: Version
+                                               , _repoPlatformAvailabilities :: [PlatformAvailability]
+                                               }
+                                               deriving (Show, Eq)
+
+data FrameworkAvailability = FrameworkAvailability { _availabilityFramework           :: FrameworkVersion
+                                                   , _frameworkPlatformAvailabilities :: [PlatformAvailability]
+                                                   }
+                                                   deriving (Show, Eq)
+
+data FrameworkVersion = FrameworkVersion { _frameworkName    :: FrameworkName
+                                         , _frameworkVersion :: Version
+                                         }
+                                         deriving (Show, Eq)
+
+data PlatformAvailability = PlatformAvailability { _availabilityPlatform :: TargetPlatform
+                                                 , _isAvailable          :: Bool
+                                                 }
+                                                 deriving (Show, Eq)

--- a/src/Data/GitRepoAvailability.hs
+++ b/src/Data/GitRepoAvailability.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
-
 module Data.GitRepoAvailability
     ( GitRepoAvailability (..)
     , FrameworkAvailability (..)

--- a/src/Data/TargetPlatform.hs
+++ b/src/Data/TargetPlatform.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Data.TargetPlatform
+    ( allTargetPlatforms
+    , readTargetPlatform
+    , targetPlatformName
+    , TargetPlatform (..)
+    ) where
+
+
+import           Control.Monad
+import           Data.Char
+import           Data.Maybe
+
+data TargetPlatform = IOS | Mac | TVOS | WatchOS
+              deriving (Eq, Show)
+
+targetPlatformName :: TargetPlatform -> String
+targetPlatformName IOS = "iOS"
+targetPlatformName Mac = "MacOS"
+targetPlatformName TVOS = "tvOS"
+targetPlatformName WatchOS = "watchOS"
+
+allTargetPlatforms = [IOS, Mac, TVOS, WatchOS]
+
+readTargetPlatform :: String -> Maybe TargetPlatform
+readTargetPlatform str = listToMaybe matchingPlatforms
+  where
+    lowercaseStr = toLower <$> str
+    matchingPlatforms = filter ((==lowercaseStr) . (liftM toLower) . targetPlatformName) allTargetPlatforms

--- a/src/Data/TargetPlatform.hs
+++ b/src/Data/TargetPlatform.hs
@@ -1,31 +1,35 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
-
 module Data.TargetPlatform
     ( allTargetPlatforms
-    , readTargetPlatform
-    , targetPlatformName
     , TargetPlatform (..)
     ) where
 
 
-import           Control.Monad
+
 import           Data.Char
 import           Data.Maybe
+import           Text.Read
+import qualified Text.Read.Lex as L
+
+
 
 data TargetPlatform = IOS | MacOS | TVOS | WatchOS
-              deriving (Ord, Eq, Show)
+              deriving (Ord, Eq)
 
-targetPlatformName :: TargetPlatform -> String
-targetPlatformName IOS = "iOS"
-targetPlatformName MacOS = "macOS"
-targetPlatformName TVOS = "tvOS"
-targetPlatformName WatchOS = "watchOS"
+instance Show TargetPlatform where
+  show IOS      = "iOS"
+  show MacOS    = "macOS"
+  show TVOS     = "tvOS"
+  show WatchOS  = "watchOS"
 
+allTargetPlatforms :: [TargetPlatform]
 allTargetPlatforms = [IOS, MacOS, TVOS, WatchOS]
 
-readTargetPlatform :: String -> Maybe TargetPlatform
-readTargetPlatform str = listToMaybe matchingPlatforms
-  where
-    lowercaseStr = toLower <$> str
-    matchingPlatforms = filter ((==lowercaseStr) . (liftM toLower) . targetPlatformName) allTargetPlatforms
+instance Read TargetPlatform where
+  readPrec = parens $ do
+    L.Ident s <- lexP
+    case map toLower s of
+       "ios"     -> return IOS
+       "macos"   -> return MacOS
+       "tvos"    -> return TVOS
+       "watchos" -> return WatchOS
+       a         -> error $ "Unrecognized platform " ++ a

--- a/src/Data/TargetPlatform.hs
+++ b/src/Data/TargetPlatform.hs
@@ -13,16 +13,16 @@ import           Control.Monad
 import           Data.Char
 import           Data.Maybe
 
-data TargetPlatform = IOS | Mac | TVOS | WatchOS
-              deriving (Eq, Show)
+data TargetPlatform = IOS | MacOS | TVOS | WatchOS
+              deriving (Ord, Eq, Show)
 
 targetPlatformName :: TargetPlatform -> String
 targetPlatformName IOS = "iOS"
-targetPlatformName Mac = "MacOS"
+targetPlatformName MacOS = "MacOS"
 targetPlatformName TVOS = "tvOS"
 targetPlatformName WatchOS = "watchOS"
 
-allTargetPlatforms = [IOS, Mac, TVOS, WatchOS]
+allTargetPlatforms = [IOS, MacOS, TVOS, WatchOS]
 
 readTargetPlatform :: String -> Maybe TargetPlatform
 readTargetPlatform str = listToMaybe matchingPlatforms

--- a/src/Data/TargetPlatform.hs
+++ b/src/Data/TargetPlatform.hs
@@ -18,7 +18,7 @@ data TargetPlatform = IOS | MacOS | TVOS | WatchOS
 
 targetPlatformName :: TargetPlatform -> String
 targetPlatformName IOS = "iOS"
-targetPlatformName MacOS = "MacOS"
+targetPlatformName MacOS = "macOS"
 targetPlatformName TVOS = "tvOS"
 targetPlatformName WatchOS = "watchOS"
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -34,6 +34,7 @@ import           Data.Conduit                 (($$))
 import           Data.Conduit.Binary          (sinkFile, sinkLbs, sourceFile,
                                                sourceLbs)
 import           Data.Function
+import           Data.GitRepoAvailability
 import           Data.Ini                     as INI
 import           Data.Ini.Utils               as INI
 import           Data.List
@@ -79,27 +80,6 @@ data RomeListPayload = RomeListPayload { _listMode      :: ListMode
                                        , _listPlatforms :: [TargetPlatform]
                                        }
                                        deriving (Show, Eq)
-
-data GitRepoAvailability = GitRepoAvailability { _availabilityRepo           :: GitRepoName
-                                               , _availabilityVersion        :: Version
-                                               , _repoPlatformAvailabilities :: [PlatformAvailability]
-                                               }
-                                               deriving (Show, Eq)
-
-data FrameworkAvailability = FrameworkAvailability { _availabilityFramework           :: FrameworkVersion
-                                                   , _frameworkPlatformAvailabilities :: [PlatformAvailability]
-                                                   }
-                                                   deriving (Show, Eq)
-
-data FrameworkVersion = FrameworkVersion { _frameworkName    :: FrameworkName
-                                         , _frameworkVersion :: Version
-                                         }
-                                         deriving (Show, Eq)
-
-data PlatformAvailability = PlatformAvailability { _availabilityPlatform :: TargetPlatform
-                                                 , _isAvailable          :: Bool
-                                                 }
-                                                 deriving (Show, Eq)
 
 data ListMode = All
                | Missing

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -112,7 +112,7 @@ platformsParser :: Opts.Parser [TargetPlatform]
 platformsParser = (nub . concat <$> Opts.some (Opts.option (eitherReader platformListOrError) (Opts.metavar "PLATFORMS" <> Opts.long "platform" <> Opts.help "Applicable platforms for the command. One of iOS, MacOS, tvOS, watchOS, or a comma-separated list of any of these values.")))
   <|> pure allTargetPlatforms
   where
-    platformOrError str = maybe (Left $ "Unrecognized platform '" ++ str ++ "'") pure (readMaybe str)
+    platformOrError str = maybeToEither ("Unrecognized platform '" ++ str ++ "'") (readMaybe str)
     splitPlatforms str = filter (not . null) $ filter isLetter <$> wordsBy (not . isLetter) str
     platformListOrError str = mapM platformOrError $ splitPlatforms str
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -140,8 +140,8 @@ listParser = List <$> listPayloadParser
 
 parseRomeCommand :: Opts.Parser RomeCommand
 parseRomeCommand = Opts.subparser $
-  Opts.command "upload" (uploadParser `withInfo` "Uploads frameworks and dSYMs contained in the local Carthage/Build/iOS to S3, according to the local Cartfile.resolved")
-  <> Opts.command "download" (downloadParser `withInfo` "Downloads and unpacks in Carthage/Build/iOS frameworks and dSYMs found in S3, according to the local Carftfile.resolved")
+  Opts.command "upload" (uploadParser `withInfo` "Uploads frameworks and dSYMs contained in the local Carthage/Build/<platform> to S3, according to the local Cartfile.resolved")
+  <> Opts.command "download" (downloadParser `withInfo` "Downloads and unpacks in Carthage/Build/<platform> frameworks and dSYMs found in S3, according to the local Carftfile.resolved")
   <> Opts.command "list" (listParser `withInfo` "Lists frameworks in the cache and reports cache misses/hits, according to the local Carftfile.resolved. Ignores dSYMs.")
 
 parseRomeOptions :: Opts.Parser RomeOptions

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,7 +1,10 @@
 module Main where
 
+import           Control.Monad
+
 import           Lib
 import           Data.Cartfile
+import           Data.GitRepoAvailability
 import           Data.Romefile
 import qualified Data.Text as T
 
@@ -11,29 +14,32 @@ import           Test.QuickCheck
 nonEmptyString :: Gen String
 nonEmptyString = listOf1 arbitrary
 
+instance Arbitrary FrameworkVersion where
+  arbitrary = liftM2 FrameworkVersion arbitrary arbitrary
+
 instance Arbitrary FrameworkName where
   arbitrary = FrameworkName <$> nonEmptyString
 
 instance Arbitrary Version where
   arbitrary = Version <$> nonEmptyString
 
-prop_filterByNameEqualTo_idempotent :: [(FrameworkName, Version)] -> FrameworkName -> Bool
+prop_filterByNameEqualTo_idempotent :: [FrameworkVersion] -> FrameworkName -> Bool
 prop_filterByNameEqualTo_idempotent ls n = filterByNameEqualTo ls n == filterByNameEqualTo (filterByNameEqualTo ls n) n
 
-prop_filterByNameEqualTo_smaller :: [(FrameworkName, Version)] -> FrameworkName -> Bool
+prop_filterByNameEqualTo_smaller :: [FrameworkVersion] -> FrameworkName -> Bool
 prop_filterByNameEqualTo_smaller ls n = length (filterByNameEqualTo ls n) <= length ls
 
-prop_filterByNameEqualTo_model :: [(FrameworkName, Version)] -> FrameworkName -> Bool
-prop_filterByNameEqualTo_model ls n = map fst (filterByNameEqualTo ls n) == filter (== n) (map fst ls)
+prop_filterByNameEqualTo_model :: [FrameworkVersion] -> FrameworkName -> Bool
+prop_filterByNameEqualTo_model ls n = map _frameworkName (filterByNameEqualTo ls n) == filter (== n) (map _frameworkName ls)
 
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent :: [(FrameworkName, Version)] -> [FrameworkName] -> Bool
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent :: [FrameworkVersion] -> [FrameworkName] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent ls ns = filterOutFrameworkNamesAndVersionsIfNotIn ls ns == filterOutFrameworkNamesAndVersionsIfNotIn (filterOutFrameworkNamesAndVersionsIfNotIn ls ns) ns
 
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller :: [(FrameworkName, Version)] -> [FrameworkName] -> Bool
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller :: [FrameworkVersion] -> [FrameworkName] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller ls ns = length (filterOutFrameworkNamesAndVersionsIfNotIn ls ns) <= length ls
 
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_model :: [(FrameworkName, Version)] -> [FrameworkName] -> Bool
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_model ls ns = map fst (filterOutFrameworkNamesAndVersionsIfNotIn ls ns) == filter (`notElem` ns) (map fst ls)
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_model :: [FrameworkVersion] -> [FrameworkName] -> Bool
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_model ls ns = map _frameworkName (filterOutFrameworkNamesAndVersionsIfNotIn ls ns) == filter (`notElem` ns) (map _frameworkName ls)
 
 prop_split_length :: Char -> String -> Property
 prop_split_length sep ls =


### PR DESCRIPTION
WIP - Still needs documentation update for usage and parsing of list command output, but wanted to get the functionality under review.

Implements #36. Platforms can be specified with the `--platform` option (`rome upload --platform ios,watchos`). The cache key is now `<framework_name>/<platform>/<framework_name>.framework-<version>.zip`.

When using the list command, the output format has been updated to `<git-repository-name> <version> : ((+|-)<platform-name>){1-4}`, for example `FrameworkA 1.0.0 : +iOS -watchOS`