### PR TITLE
Fix/carthage-mac-dir

### DIFF
--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.10.0.21
+version:             0.10.1.22
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import           Options.Applicative  as Opts
 
 
 romeVersion :: String
-romeVersion = "0.10.0.21"
+romeVersion = "0.10.1.22"
 
 
 

--- a/src/Data/Carthage/TargetPlatform.hs
+++ b/src/Data/Carthage/TargetPlatform.hs
@@ -10,7 +10,7 @@ data TargetPlatform = IOS | MacOS | TVOS | WatchOS
 
 instance Show TargetPlatform where
  show IOS      = "iOS"
- show MacOS    = "macOS"
+ show MacOS    = "Mac"
  show TVOS     = "tvOS"
  show WatchOS  = "watchOS"
 


### PR DESCRIPTION
Changes the show instance for MacOS platform from "macOS" to "Mac" to match carthage build dirs.