### PR TITLE
v0.12.0.31 - Spurius Lartius

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 codex.tags
+_Dangerfile.tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 # Choose a lightweight base image; we provide our own build tools.
 language: c
 
+
 # GHC depends on GMP. You can add other dependencies here as well.
 addons:
   apt:
@@ -17,15 +18,25 @@ env:
 - ARGS="--resolver=lts-7"
 
 before_install:
+# Update ruby
+- rvm use 2.1 --install --binary --fuzzy
+
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
+# Download and instal hlint
+- rake
+
+install:
+  - bundle install
+
 # This line does all of the work: installs GHC if necessary, build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
 script:
+  - bundle exec danger
   - stack $ARGS setup
   - stack $ARGS test --no-terminal --haddock --no-haddock-deps
   - stack $ARGS build

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,20 @@
+# Sometimes it's a README fix, or something like that - which isn't relevant for
+# including in a project's CHANGELOG for example
+declared_trivial = github.pr_title.include? "#trivial"
+
+# Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
+
+# Warn when there is a big PR
+warn("Big PR") if git.lines_of_code > 500
+
+
+affected_files = git.added_files + git.modified_files
+
+haskell_files = affected_files.select { |file| file.end_with?('.hs') }
+
+hlint.lint(haskell_files, true)
+
+# Don't let testing shortcuts get into master by accident
+fail("fdescribe left in tests") if `grep -r fdescribe specs/ `.length > 1
+fail("fit left in tests") if `grep -r fit specs/ `.length > 1

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+gem "danger"
+gem "danger-hlint"
+gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,64 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    claide (1.0.2)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    coderay (1.1.1)
+    colored2 (3.1.2)
+    cork (0.3.0)
+      colored2 (~> 3.1)
+    danger (5.3.3)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1)
+      kramdown (~> 1.5)
+      octokit (~> 4.7)
+      terminal-table (~> 1)
+    danger-hlint (0.0.2)
+      danger-plugin-api (~> 1.0)
+    danger-plugin-api (1.0.0)
+      danger (> 2.0)
+    faraday (0.12.1)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
+    git (1.3.0)
+    kramdown (1.14.0)
+    method_source (0.8.2)
+    multipart-post (2.0.0)
+    nap (1.1.0)
+    octokit (4.7.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (2.0.5)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    slop (3.6.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  danger
+  danger-hlint
+  pry
+
+BUNDLED WITH
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
       kramdown (~> 1.5)
       octokit (~> 4.7)
       terminal-table (~> 1)
-    danger-hlint (0.0.2)
+    danger-hlint (0.0.3)
       danger-plugin-api (~> 1.0)
     danger-plugin-api (1.0.0)
       danger (> 2.0)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ as a shared cache for frameworks built with [Carthage](https://github.com/Cartha
 		- [Uploading](#uploading)
 		- [Downloading](#downloading)
 		- [Listing](#listing)
-- [Troubleshooting](#troubleshooting-faq)
+- [Troubleshooting](#troubleshooting--faq)
 	- [Getting "Image not found" when running an application using binaries](#getting-image-not-found-when-running-an-application-using-binaries)
 	- [Supporting multiple Swift Versions](#supporting-multiple-swift-versions)
 - [Presentations and Tutorials](#presentations-and-tutorials)
@@ -443,7 +443,6 @@ achieved by specifying a cache prefix when using any Rome command like so:
 $ rome upload --platform iOS --cache-prefix Swift3 Alamofire
 $ rome download --platform iOS --cache-prefix Swift3 Alamofire
 $ rome list --platform iOS --cache-prefix Swift3
-
 ```
 
 The specified prefix is prepended to the git repository name in the caches.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ as a shared cache for frameworks built with [Carthage](https://github.com/Cartha
 		- [Uploading](#uploading)
 		- [Downloading](#downloading)
 		- [Listing](#listing)
-- [Troubleshooting](#troubleshooting--faq)
+- [Troubleshooting & FAQ](#troubleshooting--faq)
 	- [Getting "Image not found" when running an application using binaries](#getting-image-not-found-when-running-an-application-using-binaries)
 	- [Supporting multiple Swift Versions](#supporting-multiple-swift-versions)
 - [Presentations and Tutorials](#presentations-and-tutorials)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ as a shared cache for frameworks built with [Carthage](https://github.com/Cartha
 		- [Uploading](#uploading)
 		- [Downloading](#downloading)
 		- [Listing](#listing)
-- [Troubleshooting](#troubleshooting)
+- [Troubleshooting](#troubleshooting-faq)
 	- [Getting "Image not found" when running an application using binaries](#getting-image-not-found-when-running-an-application-using-binaries)
+	- [Supporting multiple Swift Versions](#supporting-multiple-swift-versions)
 - [Presentations and Tutorials](#presentations-and-tutorials)
 - [Who uses Rome?](#who-uses-rome)
 - [License](#license)
@@ -416,7 +417,7 @@ Note: `list` __completely ignores dSYMs and Carthage version files__. If a dSYM
 or a [Carthage version file](https://github.com/Carthage/Carthage/blob/master/Documentation/VersionFile.md)
 is missing, __the corresponding framework is still reported as present__.
 
-## Troubleshooting
+## Troubleshooting & FAQ
 
 ### Getting "Image not found" when running an application using binaries
 
@@ -432,6 +433,23 @@ To fix that, add an explicit import statement to one of your files:
 import CoreLocation
 import MapKit
 ```
+
+### Supporting multiple Swift Versions
+
+Storing artifacts or a the same famework at different Swift versions can be
+achieved by specifying a cache prefix when using any Rome command like so:
+
+```
+$ rome upload --platform iOS --cache-prefix Swift3 Alamofire
+$ rome download --platform iOS --cache-prefix Swift3 Alamofire
+$ rome list --platform iOS --cache-prefix Swift3
+
+```
+
+The specified prefix is prepended to the git repository name in the caches.
+Using a local cache path like `~/Library/Caches/Rome` will store Alamofire from
+the example above at `~/Library/Caches/Rome/Swift3/Alamofire`
+
 ## Presentations and Tutorials
 
 Video tutorial on Rome given at [CocoaHeads Berlin](http://cocoaheads-berlin.org/) and [slides](https://speakerdeck.com/blender/caching-a-simple-solution-to-speeding-up-build-times)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,27 @@
+
+namespace :hlint do
+
+  desc "Download and install hlint"
+  task :install do
+    REPO = "https://github.com/ndmitchell/hlint"
+    VERSION = "2.0.9"#DangerHlint::HLINT_VERSION
+    ASSET = "hlint-#{VERSION}-x86_64-linux.tar.gz"
+    URL = "#{REPO}/releases/download/v#{VERSION}/#{ASSET}"
+    DESTINATION_BASE = File.expand_path(File.join(File.dirname(__FILE__), 'bin'))
+    DESTINATION_TMP = File.join("#{DESTINATION_BASE}", 'tmp')
+
+    puts "Downloading hlint@v#{VERSION}"
+    sh [
+      "mkdir -p #{DESTINATION_TMP}",
+      "curl -s -L #{URL} -o #{ASSET}",
+      "tar -xf #{ASSET} -C #{DESTINATION_TMP}",
+      "cp #{DESTINATION_TMP}/hlint-#{VERSION}/hlint #{File.expand_path("~/.local/bin")}",
+      "cp -R #{DESTINATION_TMP}/hlint-#{VERSION}/data #{File.expand_path("~/.local/bin")}",
+      "rm -r #{DESTINATION_BASE}/",
+      "rm #{ASSET}"
+    ].join(" && ")
+  end
+
+end
+
+task default: 'hlint:install'

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.11.0.27
+version:             0.11.1.28
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome
@@ -42,6 +42,8 @@ library
                        , containers >= 0.5
                        , unordered-containers >= 0.2.7
                        , conduit >= 1.2
+                       , http-conduit >= 2.1.0
+                       , http-types >= 0.9
                        , conduit-extra >= 1.1
                        , ini >= 0.3.5
                        , split >= 0.2.1.3
@@ -54,7 +56,6 @@ library
                        , resourcet >= 1.1
                        , optparse-applicative >= 0.12
                        , aeson >= 0.11
-                       , lens >= 4.13
 
   ghc-options:         -Wall -fno-warn-unused-do-bind
 

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.12.0.29
+version:             0.12.0.30
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.11.1.28
+version:             0.12.0.29
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.12.0.30
+version:             0.12.0.31
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import           System.Exit
 
 
 romeVersion :: RomeVersion
-romeVersion = (0, 12, 0, 29)
+romeVersion = (0, 12, 0, 30)
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import           System.Exit
 
 
 romeVersion :: RomeVersion
-romeVersion = (0, 11, 1, 28)
+romeVersion = (0, 12, 0, 29)
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,8 +8,8 @@ import           System.Exit
 
 
 
-romeVersion :: String
-romeVersion = "0.11.0.27"
+romeVersion :: RomeVersion
+romeVersion = (0, 11, 1, 28)
 
 
 
@@ -19,9 +19,9 @@ main = do
   let opts = info (Opts.helper <*> Opts.flag' Nothing (Opts.long "version" <> Opts.help "Prints the version information" <> Opts.hidden ) <|> Just <$> parseRomeOptions) (header "S3 cache tool for Carthage" )
   cmd <- execParser opts
   case cmd of
-    Nothing -> putStrLn $ romeVersion ++ " - Romam uno die non fuisse conditam."
+    Nothing -> putStrLn $ romeVersionToString romeVersion ++ " - Romam uno die non fuisse conditam."
     Just romeOptions -> do
-      p <- runExceptT $ runRomeWithOptions romeOptions
+      p <- runExceptT $ runRomeWithOptions romeOptions romeVersion
       case p of
         Right _ -> return ()
         Left e  -> die e

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import           System.Exit
 
 
 romeVersion :: RomeVersion
-romeVersion = (0, 12, 0, 30)
+romeVersion = (0, 12, 0, 31)
 
 
 

--- a/src/CommandParsers.hs
+++ b/src/CommandParsers.hs
@@ -19,9 +19,11 @@ import           Types.Commands
 -- verifyParser :: Parser VerifyFlag
 -- verifyParser = VerifyFlag <$> Opts.switch ( Opts.long "verify" <> Opts.help "Verify that the framework has the same hash as specified in the Cartfile.resolved.")
 
+cachePrefixParser :: Parser String
+cachePrefixParser = Opts.strOption (Opts.value "" <> Opts.metavar "PREFIX" <> Opts.long "cache-prefix" <> Opts.help "A prefix appended to the top level directories inside the caches. Usefull to separate artifacts between Swift versions.")
 
 skipLocalCacheParser :: Parser SkipLocalCacheFlag
-skipLocalCacheParser = SkipLocalCacheFlag <$> Opts.switch ( Opts.long "skip-local-cache" <> Opts.help "Ignore the local cache when performing the operation.")
+skipLocalCacheParser = SkipLocalCacheFlag <$> Opts.switch (Opts.long "skip-local-cache" <> Opts.help "Ignore the local cache when performing the operation.")
 
 reposParser :: Opts.Parser [GitRepoName]
 reposParser = Opts.many (Opts.argument (GitRepoName <$> str) (Opts.metavar "FRAMEWORKS..." <> Opts.help "Zero or more framework names. If zero, all frameworks and dSYMs are uploaded."))
@@ -35,7 +37,7 @@ platformsParser = (nub . concat <$> Opts.some (Opts.option (eitherReader platfor
     platformListOrError s = mapM platformOrError $ splitPlatforms s
 
 udcPayloadParser :: Opts.Parser RomeUDCPayload
-udcPayloadParser = RomeUDCPayload <$> reposParser <*> platformsParser {- <*> verifyParser-} <*> skipLocalCacheParser
+udcPayloadParser = RomeUDCPayload <$> reposParser <*> platformsParser <*> cachePrefixParser <*> skipLocalCacheParser
 
 uploadParser :: Opts.Parser RomeCommand
 uploadParser = pure Upload <*> udcPayloadParser
@@ -51,7 +53,7 @@ listModeParser = (
                 <|> Opts.flag All All (Opts.help "Reports missing or present status of frameworks in the cache. Ignores dSYMs.")
 
 listPayloadParser :: Opts.Parser RomeListPayload
-listPayloadParser = RomeListPayload <$> listModeParser <*> platformsParser
+listPayloadParser = RomeListPayload <$> listModeParser <*> platformsParser <*> cachePrefixParser
 
 listParser :: Opts.Parser RomeCommand
 listParser = List <$> listPayloadParser

--- a/src/Data/Romefile.hs
+++ b/src/Data/Romefile.hs
@@ -20,8 +20,8 @@ module Data.Romefile
     )
 where
 
-import           Control.Monad.Except
 import           Control.Lens
+import           Control.Monad.Except
 import           Data.HashMap.Strict   as M
 import           Data.Ini              as INI
 import           Data.Ini.Utils        as INI
@@ -59,8 +59,6 @@ repositoryMapEntries = lens _repositoryMapEntries (\parseResult n -> parseResult
 
 ignoreMapEntries :: Lens' RomeFileParseResult [RomefileEntry]
 ignoreMapEntries = lens _ignoreMapEntries (\parseResult n -> parseResult { _ignoreMapEntries = n })
-
-
 
 
 
@@ -142,6 +140,8 @@ getRomefileEntries sectionDelimiter ini = do
          (FrameworkName . unpack . strip)
          (splitOn "," frameworkCommonNames)))
     (M.toList m)
+
+
 
 -- | Take a path and makes it absolute resolving ../ and ~
 -- See https://www.schoolofhaskell.com/user/dshevchenko/cookbook/transform-relative-path-to-an-absolute-path

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -894,9 +894,8 @@ deleteFrameworkDirectory :: MonadIO m
                          -> Bool -- ^ A flag controlling verbosity
                          -> m ()
 deleteFrameworkDirectory (FrameworkVersion f _)
-                         platform
-                         verbose =
-  deleteDirectory frameworkDirectory verbose
+                         platform =
+  deleteDirectory frameworkDirectory
   where
     frameworkNameWithFrameworkExtension = appendFrameworkExtensionTo f
     platformBuildDirectory = carthageBuildDirectoryForPlatform platform
@@ -911,9 +910,8 @@ deleteDSYMDirectory :: MonadIO m
                     -> Bool -- ^ A flag controlling verbosity
                     -> m ()
 deleteDSYMDirectory (FrameworkVersion f _)
-                    platform
-                    verbose =
-  deleteDirectory dSYMDirectory verbose
+                    platform =
+  deleteDirectory dSYMDirectory
   where
     frameworkNameWithFrameworkExtension = appendFrameworkExtensionTo f
     platformBuildDirectory = carthageBuildDirectoryForPlatform platform

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -16,6 +16,8 @@ type RomeMonad             = ExceptT String IO
 type RepositoryMap         = M.Map GitRepoName [FrameworkName]
 type InvertedRepositoryMap = M.Map FrameworkName GitRepoName
 
+type RomeVersion           = (Int, Int, Int, Int)
+
 type GitRepoNameAndVersion = (GitRepoName, Version)
 
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -11,7 +11,8 @@ import           Types.Commands
 
 
 
-type UDCEnv                = (AWS.Env,{-, VerifyFlag-}SkipLocalCacheFlag, Bool)
+type UploadDownloadCmdEnv  = (AWS.Env, CachePrefix, SkipLocalCacheFlag, Bool)
+type UploadDownloadEnv     = (AWS.Env, CachePrefix, Bool)
 type RomeMonad             = ExceptT String IO
 type RepositoryMap         = M.Map GitRepoName [FrameworkName]
 type InvertedRepositoryMap = M.Map FrameworkName GitRepoName
@@ -20,6 +21,11 @@ type RomeVersion           = (Int, Int, Int, Int)
 
 type GitRepoNameAndVersion = (GitRepoName, Version)
 
+-- | A wrapper around `String` used to specify what prefix to user
+-- | when determining remote paths of artifacts
+
+newtype CachePrefix = CachePrefix { _unCachePrefix :: String }
+                                  deriving (Show, Eq)
 
 -- | Represents the name of a framework together with its version
 data FrameworkVersion = FrameworkVersion { _frameworkName    :: FrameworkName

--- a/src/Types/Commands.hs
+++ b/src/Types/Commands.hs
@@ -10,6 +10,7 @@ data RomeCommand = Upload RomeUDCPayload
 
 data RomeUDCPayload = RomeUDCPayload { _payload            :: [GitRepoName]
                                      , _udcPlatforms       :: [TargetPlatform]
+                                     , _cachePrefix        :: String
                                     --  , _verifyFlag         :: VerifyFlag
                                      , _skipLocalCacheFlag :: SkipLocalCacheFlag
                                      }
@@ -20,8 +21,9 @@ data RomeUDCPayload = RomeUDCPayload { _payload            :: [GitRepoName]
 newtype SkipLocalCacheFlag = SkipLocalCacheFlag { _skipLocalCache :: Bool }
                                                 deriving (Show, Eq)
 
-data RomeListPayload = RomeListPayload { _listMode      :: ListMode
-                                       , _listPlatforms :: [TargetPlatform]
+data RomeListPayload = RomeListPayload { _listMode        :: ListMode
+                                       , _listPlatforms   :: [TargetPlatform]
+                                       , _listCachePrefix :: String
                                        }
                                        deriving (Show, Eq)
 

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -373,3 +373,6 @@ greenControlSequence = "\ESC[0;32m"
 
 noColorControlSequence :: String
 noColorControlSequence = "\ESC[0m"
+
+third :: (a, b, c) -> c
+third (_, _, c) = c

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -30,6 +30,7 @@ import qualified Network.AWS                  as AWS (Error, ErrorMessage (..),
                                                       _ServiceError)
 import           Network.HTTP.Conduit         as HTTP
 import           Network.HTTP.Types.Header    as HTTP (hUserAgent)
+import           Numeric                      (showFFloat)
 import           System.FilePath
 import           Text.Read                    (readMaybe)
 import           Types
@@ -97,10 +98,11 @@ sayLnWithTime line = do
 
 
 
--- | Given a number n representing bytes, gives an approximation in Megabytes.
-roundBytesToMegabytes :: Integral n => n -> Double
-roundBytesToMegabytes n = fromInteger (round (nInMB * (10^2))) / (10.0^^2)
+-- | Given a number n representing bytes, shows it in MB, rounded to 2 decimal places.
+showInMegabytes :: Integral n => n -> String
+showInMegabytes n = showFFloat (Just 2) nInMB " MB"
   where
+    nInMB :: Double
     nInMB = fromIntegral n / (1024*1024)
 
 


### PR DESCRIPTION
- Add out of date version check when running upload or download commands #75.  
- Allow a prefix for top level directories to be specified for all commands. Useful to store frameworks built with different Swift versions #83 #82. See [Supporting multiple Swift Versions](https://github.com/blender/Rome/tree/e291ecc66ad27c260d0f09359ff603d8512ffb44#supporting-multiple-swift-versions) for reference.