### PR TITLE
Parallelise s3 cache probing

### DIFF
--- a/Rome.cabal
+++ b/Rome.cabal
@@ -56,6 +56,7 @@ library
                        , resourcet >= 1.1
                        , optparse-applicative >= 0.12
                        , aeson >= 0.11
+                       , lifted-async >= 0.9
 
   ghc-options:         -Wall -fno-warn-unused-do-bind
 


### PR DESCRIPTION
Just gave #79 a try.

Disclaimer: I don't have a Carthage dev environment, so this it completely untested (but it typechecks :wink: ).
Please try if it works as intended before merging!


Commit 1 just parallelises the requests with minimal changes to existing code using `async-lifted`.
`async` in itself is a really nice library, but it wants the parallelised actions to be `IO` actions and since we have a `ReaderT s IO` here, we can't use it. `async-lifted` provides a more general interface using `MonadBaseControl` which we can use.

Commit 2 makes the code more concise, removing one top level function. I find this version to be more understandable (less passing around of long arguments), but that might be different for other people.

Commit 3 avoids `MonadBaseControl` and uses plain `async`, but needs to do some additional gymnastics to run the ReaderT.


By deciding which commits to pick, you can choose the version you want ;)
Minimal changes, more concise, avoiding async-lifted...
