### PR TITLE
Make Rome build with lts-9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
 env:
-- ARGS="--resolver=lts-6"
-- ARGS="--resolver=lts-7"
+- ARGS="--resolver=lts-8"
+- ARGS="--resolver=lts-9"
 
 before_install:
 # Update ruby

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -30,7 +30,7 @@ library
                        , Text.Parsec.Utils
 
   build-depends:       base >= 4.7 && < 5
-                       , amazonka >= 1.4.1
+                       , amazonka >= 1.4.3
                        , amazonka-s3 >= 1.4.1
                        , exceptions >= 0.8
                        , lens >= 4.13
@@ -43,6 +43,7 @@ library
                        , unordered-containers >= 0.2.7
                        , conduit >= 1.2
                        , http-conduit >= 2.1.0
+                       , http-client >= 0.5
                        , http-types >= 0.9
                        , conduit-extra >= 1.1
                        , ini >= 0.3.5

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import           Data.Monoid          ((<>))
 import           CommandParsers       (parseRomeOptions)
 import           Control.Monad.Except
 import           Lib

--- a/src/CommandParsers.hs
+++ b/src/CommandParsers.hs
@@ -7,6 +7,7 @@ import           Data.Char                    (isLetter)
 import           Data.Either.Utils            (maybeToEither)
 import           Data.List                    (nub)
 import           Data.List.Split              (wordsBy)
+import           Data.Monoid                  ((<>))
 import           Data.Romefile
 import           Options.Applicative          as Opts
 import           Text.Read                    (readMaybe)

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -47,10 +47,10 @@ romeVersionToString (major, minor, patch, build) = show major <> "." <> show min
 -- | Check if the given `RomeVersion` is the latest version compared to GitHub releases
 checkIfRomeLatestVersionIs :: MonadIO m => RomeVersion -> ExceptT String m (Bool, RomeVersion)
 checkIfRomeLatestVersionIs currentRomeVersion = do
-  req <- liftIO $ HTTP.parseUrl "https://api.github.com/repos/blender/Rome/releases/latest"
+  req <- liftIO $ HTTP.parseRequest "https://api.github.com/repos/blender/Rome/releases/latest"
 
   let headers = HTTP.requestHeaders req <> [(HTTP.hUserAgent, userAgent)]
-  let req' = req { HTTP.responseTimeout = Just timeout, HTTP.requestHeaders = headers }
+  let req' = req { HTTP.responseTimeout = timeout, HTTP.requestHeaders = headers }
 
   manager <- liftIO $ HTTP.newManager HTTP.tlsManagerSettings
 
@@ -64,7 +64,7 @@ checkIfRomeLatestVersionIs currentRomeVersion = do
       stringToVersionTuple = versionTupleOrZeros . map (fromMaybe 0 . readMaybe . T.unpack) . take 4 . splitWithSeparator '.' . T.pack . dropWhile (not . isNumber)
       versionTupleOrZeros a = (fromMaybe 0 (a !!? 0), fromMaybe 0 (a !!? 1), fromMaybe 0 (a !!? 2), fromMaybe 0 (a !!? 3))
 
-      timeout = 1000000 -- 1 second timeout, in microseconds
+      timeout = responseTimeoutMicro 1000000 -- 1 second
       userAgent = BS.pack $ "Rome/" <> romeVersionToString currentRomeVersion
 
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-6.0
+resolver: lts-9.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
I just saw that Rome still uses `lts-6.0` and tried building it with the latest `lts-9.0`. I only needed to fix a few minor things, but now we have two new lower bounds to make it build:

- **http-client-0.5** (ties us to LTS versions >= 8.0)
  This is because `responseTimeout` in [`Request`](https://www.stackage.org/haddock/lts-9.0/http-conduit-2.2.3.2/Network-HTTP-Conduit.html#t:Request) now has it's own type instead of just `Maybe Int`.

- **amazonka-1.4.3**
  [`newEnv`](https://www.stackage.org/haddock/lts-9.0/amazonka-1.4.5/Network-AWS.html#v:newEnv) now looks up the region from the `AWS_REGION` environment variable instead of accepting it as a parameter.
  To keep the existing behavior, I explicitly set it to the value determined from reading the config file. Could be changed in the future.

Is this something you are interested in?