### PR TITLE
Romefile yaml

### DIFF
--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.16.0.46
+version:             0.17.0.47
 synopsis:            An S3 cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome
@@ -37,7 +37,6 @@ library
                        , Caches.Local.Downloading
                        , Caches.Common
 
-
   build-depends:       base >= 4.7 && < 5
                        , amazonka >= 1.6
                        , amazonka-s3 >= 1.6
@@ -68,6 +67,8 @@ library
                        , lifted-async >= 0.9.3
                        , url >= 2.1
                        , extra >= 1.5.3
+                       , yaml >= 0.9.0
+                       , safe >= 0.3.17
 
   ghc-options:         -Wall -fno-warn-unused-do-bind
 
@@ -98,6 +99,8 @@ test-suite Rome-test
                      , hspec >= 2.2.3
                      , text >= 1.2
                      , parsec
+                     , yaml >= 0.9.0
+                     
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -fno-warn-unused-do-bind
   default-language:    Haskell2010
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,7 @@ main = do
         <|> Just
         <$> parseRomeOptions
         )
-        (header "S3 cache tool for Carthage")
+        (header "Cache tool for Carthage")
   cmd <- execParser opts
   case cmd of
     Nothing ->

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -116,7 +116,7 @@ saveBinaryToLocalCache cachePath binaryZip destinationPath objectName verbose =
 -- | Saves a list of .version files to a local cache
 saveVersionFilesToLocalCache
   :: FilePath -- ^ The cache definition.
-  -> [GitRepoNameAndVersion] -- ^ The information used to derive the name and path for the .version file.
+  -> [ProjectNameAndVersion] -- ^ The information used to derive the name and path for the .version file.
   -> ReaderT (CachePrefix, Bool) IO ()
 saveVersionFilesToLocalCache lCacheDir =
   mapM_ (saveVersonFileToLocalCache lCacheDir)
@@ -126,9 +126,9 @@ saveVersionFilesToLocalCache lCacheDir =
 -- | Saves a .version file to a local Cache
 saveVersonFileToLocalCache
   :: FilePath -- ^ The cache definition.
-  -> GitRepoNameAndVersion -- ^ The information used to derive the name and path for the .version file.
+  -> ProjectNameAndVersion -- ^ The information used to derive the name and path for the .version file.
   -> ReaderT (CachePrefix, Bool) IO ()
-saveVersonFileToLocalCache lCacheDir gitRepoNameAndVersion = do
+saveVersonFileToLocalCache lCacheDir projectNameAndVersion = do
   (cachePrefix, verbose) <- ask
   versionFileExists      <- liftIO $ doesFileExist versionFileLocalPath
 
@@ -137,10 +137,10 @@ saveVersonFileToLocalCache lCacheDir gitRepoNameAndVersion = do
     saveVersionFileBinaryToLocalCache lCacheDir
                                       cachePrefix
                                       versionFileContent
-                                      gitRepoNameAndVersion
+                                      projectNameAndVersion
                                       verbose
  where
-  versionFileName = versionFileNameForGitRepoName $ fst gitRepoNameAndVersion
+  versionFileName = versionFileNameForProjectName $ fst projectNameAndVersion
   versionFileLocalPath = carthageBuildDirectory </> versionFileName
 
 
@@ -151,14 +151,14 @@ saveVersionFileBinaryToLocalCache
   => FilePath -- ^ The destinationf file.
   -> CachePrefix -- ^ A prefix for folders at top level in the cache.
   -> LBS.ByteString -- ^ The contents of the .version file
-  -> GitRepoNameAndVersion  -- ^ The information used to derive the name and path for the .version file.
+  -> ProjectNameAndVersion  -- ^ The information used to derive the name and path for the .version file.
   -> Bool -- ^ A flag controlling verbosity.
   -> m ()
-saveVersionFileBinaryToLocalCache lCacheDir (CachePrefix prefix) versionFileContent gitRepoNameAndVersion
+saveVersionFileBinaryToLocalCache lCacheDir (CachePrefix prefix) versionFileContent projectNameAndVersion
   = saveBinaryToLocalCache lCacheDir
                            versionFileContent
                            (prefix </> versionFileRemotePath)
                            versionFileName
  where
-  versionFileName = versionFileNameForGitRepoName $ fst gitRepoNameAndVersion
-  versionFileRemotePath = remoteVersionFilePath gitRepoNameAndVersion
+  versionFileName = versionFileNameForProjectName $ fst projectNameAndVersion
+  versionFileRemotePath = remoteVersionFilePath projectNameAndVersion

--- a/src/Caches/S3/Downloading.hs
+++ b/src/Caches/S3/Downloading.hs
@@ -76,12 +76,12 @@ getDSYMFromS3 s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn fwt
 -- | Retrieves a .version file from S3
 getVersionFileFromS3
   :: S3.BucketName
-  -> GitRepoNameAndVersion
+  -> ProjectNameAndVersion
   -> ExceptT
        String
        (ReaderT (AWS.Env, CachePrefix, Bool) IO)
        LBS.ByteString
-getVersionFileFromS3 s3BucketName gitRepoNameAndVersion = do
+getVersionFileFromS3 s3BucketName projectNameAndVersion = do
   (env, CachePrefix prefix, verbose) <- ask
   let finalVersionFileRemotePath = prefix </> versionFileRemotePath
   mapExceptT (withReaderT (const (env, verbose))) $ getArtifactFromS3
@@ -89,8 +89,8 @@ getVersionFileFromS3 s3BucketName gitRepoNameAndVersion = do
     finalVersionFileRemotePath
     versionFileName
  where
-  versionFileName = versionFileNameForGitRepoName $ fst gitRepoNameAndVersion
-  versionFileRemotePath = remoteVersionFilePath gitRepoNameAndVersion
+  versionFileName = versionFileNameForProjectName $ fst projectNameAndVersion
+  versionFileRemotePath = remoteVersionFilePath projectNameAndVersion
 
 
 

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -86,9 +86,9 @@ uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap (Framew
 uploadVersionFileToS3
   :: S3.BucketName -- ^ The cache definition.
   -> LBS.ByteString -- ^ The contents of the .version file.
-  -> GitRepoNameAndVersion -- ^ The information used to derive the name and path for the .version file.
+  -> ProjectNameAndVersion -- ^ The information used to derive the name and path for the .version file.
   -> ReaderT (AWS.Env, CachePrefix, Bool) IO ()
-uploadVersionFileToS3 s3BucketName versionFileContent gitRepoNameAndVersion =
+uploadVersionFileToS3 s3BucketName versionFileContent projectNameAndVersion =
   do
     (env, CachePrefix prefix, verbose) <- ask
     withReaderT (const (env, verbose)) $ uploadBinary
@@ -98,8 +98,8 @@ uploadVersionFileToS3 s3BucketName versionFileContent gitRepoNameAndVersion =
       versionFileName
  where
 
-  versionFileName = versionFileNameForGitRepoName $ fst gitRepoNameAndVersion
-  versionFileRemotePath = remoteVersionFilePath gitRepoNameAndVersion
+  versionFileName = versionFileNameForProjectName $ fst projectNameAndVersion
+  versionFileRemotePath = remoteVersionFilePath projectNameAndVersion
 
 
 

--- a/src/CommandParsers.hs
+++ b/src/CommandParsers.hs
@@ -42,10 +42,10 @@ noIgnoreParser = NoIgnoreFlag <$> Opts.switch
        "Ignore the [IgnoreMap] section in the current Romefile when performing the operation."
   )
 
-reposParser :: Opts.Parser [GitRepoName]
+reposParser :: Opts.Parser [ProjectName]
 reposParser = Opts.many
   (Opts.argument
-    (GitRepoName <$> str)
+    (ProjectName <$> str)
     (  Opts.metavar "FRAMEWORKS..."
     <> Opts.help
          "Zero or more framework names. If zero, all frameworks and dSYMs are uploaded."
@@ -128,6 +128,21 @@ listPayloadParser =
 listParser :: Opts.Parser RomeCommand
 listParser = List <$> listPayloadParser
 
+utilsPayloadParser :: Opts.Parser RomeUtilsPayload
+utilsPayloadParser =  RomeUtilsPayload <$> romeUtilsSubcommandParser
+
+romeUtilsSubcommandParser :: Opts.Parser RomeUtilsSubcommand
+romeUtilsSubcommandParser =  Opts.subparser 
+  $ Opts.command
+      "migrate-romefile" 
+      (pure MigrateRomefile
+      `withInfo` "Migrates a Romefile from INI to YAML."
+      )
+
+
+utilsParser :: Opts.Parser RomeCommand
+utilsParser = Utils <$> utilsPayloadParser
+
 parseRomeCommand :: Opts.Parser RomeCommand
 parseRomeCommand =
   Opts.subparser
@@ -145,6 +160,11 @@ parseRomeCommand =
          "list"
          (listParser
          `withInfo` "Lists frameworks in the cache and reports cache misses/hits, according to the local Cartfile.resolved. Ignores dSYMs."
+         )
+    <> Opts.command
+         "utils"
+         (utilsParser
+         `withInfo` "A series of utilities to make life easier. `rome utils --help` to know more"
          )
 
 parseRomeOptions :: Opts.Parser RomeOptions

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -1,9 +1,12 @@
 module Configuration where
 
 
+import           Control.Applicative             ((<|>))
+import           Control.Arrow                   (left)
 import           Control.Monad.Except
 import           Data.Carthage.Cartfile
 import           Data.Carthage.TargetPlatform
+import           Data.Yaml                       (decodeFileEither, prettyPrintParseException)
 import           Data.Monoid                     ((<>))
 import           Data.Romefile
 import qualified Data.Text.IO                    as T
@@ -19,10 +22,13 @@ getCartfileEntires = do
     Left e -> throwError $ "Carfile.resolved parse error: " ++ show e
     Right cartfileEntries -> return cartfileEntries
 
-getRomefileEntries :: RomeMonad RomeFileParseResult
-getRomefileEntries =
-  withExceptT toErr $ ExceptT $ parseRomefile <$> T.readFile romefile
-  where toErr e = "Error while parsing " <> romefile <> ": " <> e
+getRomefileEntries :: RomeMonad RomeFile
+getRomefileEntries = 
+  let fromYaml = ExceptT $ left prettyPrintParseException <$> decodeFileEither romefileName
+      fromIni = ExceptT $ parseRomefile <$> T.readFile romefileName 
+      in
+        withExceptT toErr $ fromYaml <|> fromIni
+  where toErr e = "Error while parsing " <> romefileName <> ": " <> e
 
 getS3ConfigFile :: MonadIO m => m FilePath
 getS3ConfigFile = (</> awsConfigFilePath) `liftM` liftIO getHomeDirectory

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -6,7 +6,7 @@ import           Data.Aeson
 import           Data.Carthage.Cartfile       (Version)
 import           Data.Carthage.TargetPlatform
 import qualified Data.Map.Strict              as M
-import           Data.Romefile                (Framework, GitRepoName)
+import           Data.Romefile                (Framework, ProjectName)
 import           GHC.Generics
 import qualified Network.AWS.Env              as AWS (Env)
 import           Types.Commands
@@ -17,12 +17,12 @@ import           Types.Commands
 type UploadDownloadCmdEnv  = (AWS.Env, CachePrefix, SkipLocalCacheFlag, Bool)
 type UploadDownloadEnv     = (AWS.Env, CachePrefix, Bool)
 type RomeMonad             = ExceptT String IO
-type RepositoryMap         = M.Map GitRepoName [Framework]
-type InvertedRepositoryMap = M.Map Framework GitRepoName
+type RepositoryMap         = M.Map ProjectName [Framework]
+type InvertedRepositoryMap = M.Map Framework ProjectName
 
 type RomeVersion           = (Int, Int, Int, Int)
 
-type GitRepoNameAndVersion = (GitRepoName, Version)
+type ProjectNameAndVersion = (ProjectName, Version)
 
 -- | A wrapper around `String` used to specify what prefix to user
 -- | when determining remote paths of artifacts
@@ -44,7 +44,7 @@ data PlatformAvailability = PlatformAvailability { _availabilityPlatform :: Targ
 
 -- | Represents the availablity of a given `GitRepoName` at a given `Version`
 -- | as a list of `PlatformAvailability`s
-data GitRepoAvailability = GitRepoAvailability { _availabilityRepo           :: GitRepoName
+data ProjectAvailability = ProjectAvailability { _availabilityProject        :: ProjectName
                                                , _availabilityVersion        :: Version
                                                , _repoPlatformAvailabilities :: [PlatformAvailability]
                                                }

--- a/src/Types/Commands.hs
+++ b/src/Types/Commands.hs
@@ -6,9 +6,10 @@ import           Data.Carthage.TargetPlatform
 data RomeCommand = Upload RomeUDCPayload
                   | Download RomeUDCPayload
                   | List RomeListPayload
+                  | Utils RomeUtilsPayload
                   deriving (Show, Eq)
 
-data RomeUDCPayload = RomeUDCPayload { _payload            :: [GitRepoName]
+data RomeUDCPayload = RomeUDCPayload { _payload            :: [ProjectName]
                                      , _udcPlatforms       :: [TargetPlatform]
                                      , _cachePrefix        :: String
                                     --  , _verifyFlag         :: VerifyFlag
@@ -16,6 +17,11 @@ data RomeUDCPayload = RomeUDCPayload { _payload            :: [GitRepoName]
                                      , _noIgnoreFlag       :: NoIgnoreFlag
                                      }
                                      deriving (Show, Eq)
+
+data RomeUtilsPayload = RomeUtilsPayload { _subcommand :: RomeUtilsSubcommand }
+                                         deriving (Show, Eq)
+
+data RomeUtilsSubcommand = MigrateRomefile deriving (Show, Eq)
 
 -- newtype VerifyFlag = VerifyFlag { _verify :: Bool } deriving (Show, Eq)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.13
+resolver: lts-12.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -49,6 +49,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - url-2.1.3
+  - yaml-0.9.0
 # Override default flag values for local packages and extra-deps
 flags: {}
 


### PR DESCRIPTION
- [x] rename a few ugly things
- [x] conform to ToJSON and FromJSON or Derive via Generics
- [x] make sure both INI and YAML Romefile formats are supported. Prefer Romefile in YAML
- [x] migrate with `rome utils migrate-romefile`
- [x] acceptance tests

Yaml example:


```yaml
respositoryMap:
- cat-framework: #look ma, 2 targets
  - name: AwesomeCats # target 1
     type: dynamic # can omit this key, default is dynamic
  - name: StaticKitties # target 2
     type: static  # if static, specify it
- HockeySDK-iOS:
  - name: HockeySDK # no need to specify dynamic
- dog-framework:
  - name: Doggos
     type: static # if static, specify it
ignoreMap:
- GDCWebServer:
  - name: GDCWebServer
     type: dynamic
cache:
  local: ~/Library/Caches/Rome
  s3Bucket: animals-bucket
```