### PR TITLE
Handle Cartfile entries with no new lines at EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ jobs:
         - brew install bats-core
       script:
         - bundle exec danger
-        - stack $ARGS setup
+        - stack $ARGS setup -j 2
         - stack $ARGS test --no-terminal --haddock --no-haddock-deps
-        - stack $ARGS build
+        - stack $ARGS build -j 2
         - stack $ARGS sdist
         - stack $ARGS install
         - travis_wait 60 bats integration-tests/dynamic-frameworks-ini.bats
@@ -77,9 +77,9 @@ jobs:
         - brew install bats-core
       script:
         - bundle exec danger
-        - stack $ARGS setup
+        - stack $ARGS setup -j 2
         - stack $ARGS test --no-terminal --haddock --no-haddock-deps
-        - stack $ARGS build
+        - stack $ARGS build -j 2
         - stack $ARGS sdist
         - stack $ARGS install
         - travis_wait 60 bats integration-tests/current-framework-yaml.bats
@@ -114,9 +114,9 @@ jobs:
         - brew install bats-core
       script:
         - bundle exec danger
-        - stack $ARGS setup
+        - stack $ARGS setup -j 2
         - stack $ARGS test --no-terminal --haddock --no-haddock-deps
-        - stack $ARGS build
+        - stack $ARGS build -j 2
         - stack $ARGS sdist
         - stack $ARGS install
         - travis_wait 60 bats integration-tests/static-frameworks-ini.bats
@@ -126,4 +126,5 @@ cache:
   directories:
   - $HOME/.local/bin
   - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
   - vendor/bundle

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ Trusted by:
 
 ## Get Rome
 ### Using Homebrew
-`$ brew install blender/homebrew-tap/rome`
-
+```
+$ brew tap blender/tap https://github.com/blender/homebrew-tap.git
+$ brew install blender/homebrew-tap/rome
+```
 ### Using CocoaPods
 Simply add the following line to your Podfile:
 ```

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -1,5 +1,5 @@
 name:                Rome
-version:             0.18.1.53
+version:             0.18.2.54
 synopsis:            A cache for Carthage
 description:         Please see README.md
 homepage:            https://github.com/blender/Rome

--- a/Rome.podspec
+++ b/Rome.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name           = 'Rome'
-  s.version        = '0.18.1.53'
+  s.version        = '0.18.2.54'
   s.summary        = 'A cache tool for Carthage'
   s.homepage       = 'https://github.com/blender/Rome'
   s.source         = { :http => "#{s.homepage}/releases/download/v#{s.version}/rome.zip" }

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,7 +10,7 @@ import           System.Exit
 
 
 romeVersion :: RomeVersion
-romeVersion = (0, 18, 1, 53)
+romeVersion = (0, 18, 2, 54)
 
 
 

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -13,6 +13,7 @@ import qualified Data.Text.IO                    as T
 import           System.Directory
 import           System.FilePath
 import           Types
+import           Debug.Trace
 
 
 getCartfileEntires :: RomeMonad [CartfileEntry]

--- a/src/Text/Parsec/Utils.hs
+++ b/src/Text/Parsec/Utils.hs
@@ -3,7 +3,7 @@
 module Text.Parsec.Utils
     ( parseWhiteSpaces
     , parseUnquotedString
-    , onceAndConsumeTill
+    -- , onceAndConsumeTill
     ) where
 
 
@@ -23,13 +23,13 @@ parseUnquotedString =
   Parsec.many1 (Parsec.noneOf ['"', ' ', '\t', '\n', '\'', '\\', '\r'])
 
 
--- | @onceOrConsumeTill p@ end@ tries to apply the parser @p@ /once/ and consumes
--- | the input until @end@. Returns a `Maybe` of the value of @p@.
--- | Thanks to Tobias Mayer, Berlin Haskell Group.
-onceAndConsumeTill
-  :: (Parsec.Stream s Identity Char)
-  => Parsec.Parsec s u a
-  -> Parsec.Parsec s u b
-  -> Parsec.Parsec s u (Maybe a)
-onceAndConsumeTill p end = Parsec.optionMaybe (Parsec.try p) <* consume
-  where consume = Parsec.try end <|> Parsec.anyChar *> consume
+-- -- | @onceOrConsumeTill p@ end@ tries to apply the parser @p@ /once/ and consumes
+-- -- | the input until @end@. Returns a `Maybe` of the value of @p@.
+-- -- | Thanks to Tobias Mayer, Berlin Haskell Group.
+-- onceAndConsumeTill
+--   :: (Parsec.Stream s Identity Char)
+--   => Parsec.Parsec s u a
+--   -> Parsec.Parsec s u b
+--   -> Parsec.Parsec s u (Maybe a)
+-- onceAndConsumeTill p end = Parsec.optionMaybe (Parsec.try p) <* consume
+--   where consume = Parsec.try end <|> Parsec.anyChar *> consume

--- a/src/Text/Parsec/Utils.hs
+++ b/src/Text/Parsec/Utils.hs
@@ -3,7 +3,6 @@
 module Text.Parsec.Utils
     ( parseWhiteSpaces
     , parseUnquotedString
-    -- , onceAndConsumeTill
     ) where
 
 

--- a/src/Text/Parsec/Utils.hs
+++ b/src/Text/Parsec/Utils.hs
@@ -21,15 +21,3 @@ parseWhiteSpaces =
 parseUnquotedString :: Parsec.Parsec String () String
 parseUnquotedString =
   Parsec.many1 (Parsec.noneOf ['"', ' ', '\t', '\n', '\'', '\\', '\r'])
-
-
--- -- | @onceOrConsumeTill p@ end@ tries to apply the parser @p@ /once/ and consumes
--- -- | the input until @end@. Returns a `Maybe` of the value of @p@.
--- -- | Thanks to Tobias Mayer, Berlin Haskell Group.
--- onceAndConsumeTill
---   :: (Parsec.Stream s Identity Char)
---   => Parsec.Parsec s u a
---   -> Parsec.Parsec s u b
---   -> Parsec.Parsec s u (Maybe a)
--- onceAndConsumeTill p end = Parsec.optionMaybe (Parsec.try p) <* consume
---   where consume = Parsec.try end <|> Parsec.anyChar *> consume


### PR DESCRIPTION
Refactor Cartfile.resolved parsing to handle lines with no EOL chars: 
- https://www.fileformat.info/info/unicode/char/000a/index.htm 
- http://www.fileformat.info/info/unicode/char/000d/index.htm

This PR addresses https://github.com/blender/Rome/issues/165 