### PR TITLE
Fix warnings

### DIFF
--- a/Rome.cabal
+++ b/Rome.cabal
@@ -71,7 +71,7 @@ library
                        , yaml >= 0.9.0
                        , safe >= 0.3.17
 
-  ghc-options:         -Wall -fno-warn-unused-do-bind
+  ghc-options:         -Wall -Werror -fno-warn-unused-do-bind
 
 
 

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -71,7 +71,7 @@ library
                        , yaml >= 0.9.0
                        , safe >= 0.3.17
 
-  ghc-options:         -Wall -Werror -fno-warn-unused-do-bind
+  ghc-options:         -Wall -fno-warn-unused-do-bind
 
 
 

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -7,7 +7,6 @@ import           Configuration
 import           Control.Monad                (unless, when)
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader         (ReaderT, ask)
-import           Debug.Trace
 import qualified Data.ByteString.Lazy         as LBS
 import           Data.Carthage.TargetPlatform
 import           Data.Monoid                  ((<>))
@@ -53,7 +52,7 @@ saveDsymToLocalCache
   -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the dSYM.
   -> TargetPlatform -- ^ A `TargetPlatform` to limit the operation to.
   -> ReaderT (CachePrefix, SkipLocalCacheFlag, Bool) IO ()
-saveDsymToLocalCache lCacheDir dSYMArchive reverseRomeMap (FrameworkVersion f@(Framework fwn fwt fwps) version) platform
+saveDsymToLocalCache lCacheDir dSYMArchive reverseRomeMap (FrameworkVersion f@(Framework fwn _ fwps) version) platform
   = when (platform `elem` fwps) $ do
     (CachePrefix prefix, SkipLocalCacheFlag skipLocalCache, verbose) <- ask
     unless skipLocalCache $ saveBinaryToLocalCache

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -25,7 +25,7 @@ uploadFrameworkToS3
   -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the Framework.
   -> TargetPlatform -- ^ A `TargetPlatform`s restricting the scope of this action.
   -> ReaderT UploadDownloadEnv IO ()
-uploadFrameworkToS3 frameworkArchive s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn fwt fwps) version) platform
+uploadFrameworkToS3 frameworkArchive s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn _ fwps) version) platform
   = when (platform `elem` fwps) $ do
     (env, CachePrefix prefix, verbose) <- ask
     withReaderT (const (env, verbose)) $ uploadBinary
@@ -47,7 +47,7 @@ uploadDsymToS3
   -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the Framework and the dSYM.
   -> TargetPlatform -- ^ A `TargetPlatform` restricting the scope of this action.
   -> ReaderT UploadDownloadEnv IO ()
-uploadDsymToS3 dSYMArchive s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn fwt fwps) version) platform
+uploadDsymToS3 dSYMArchive s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn _ fwps) version) platform
   = when (platform `elem` fwps) $ do
     (env, CachePrefix prefix, verbose) <- ask
     withReaderT (const (env, verbose)) $ uploadBinary
@@ -68,7 +68,7 @@ uploadBcsymbolmapToS3
   -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the Framework and the dSYM.
   -> TargetPlatform -- ^ A `TargetPlatform` restricting the scope of this action.
   -> ReaderT UploadDownloadEnv IO ()
-uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn fwt fwps) version) platform
+uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn _ fwps) version) platform
   = when (platform `elem` fwps) $ do
     (env, CachePrefix prefix, verbose) <- ask
     withReaderT (const (env, verbose)) $ uploadBinary

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -13,7 +13,6 @@ import qualified Data.Text.IO                    as T
 import           System.Directory
 import           System.FilePath
 import           Types
-import           Debug.Trace
 
 
 getCartfileEntries :: RomeMonad [CartfileEntry]
@@ -45,7 +44,7 @@ carthageBuildDirectory = "Carthage" </> "Build"
 --   from `Framework`. Ignores the `TargetPlatform` list in `Framework`
 carthageArtifactsBuildDirectoryForPlatform
   :: TargetPlatform -> Framework -> FilePath
-carthageArtifactsBuildDirectoryForPlatform platform (Framework n Dynamic _) =
+carthageArtifactsBuildDirectoryForPlatform platform (Framework _ Dynamic _) =
   carthageBuildDirectory </> show platform
-carthageArtifactsBuildDirectoryForPlatform platform (Framework n Static _) =
+carthageArtifactsBuildDirectoryForPlatform platform (Framework _ Static _) =
   carthageBuildDirectory </> show platform </> "Static"

--- a/src/Data/Carthage/Cartfile.hs
+++ b/src/Data/Carthage/Cartfile.hs
@@ -17,7 +17,6 @@ import qualified Text.Parsec          as Parsec
 import qualified Text.Parsec.String   as Parsec
 import qualified Text.Parsec.Utils    as Parsec
 import           Data.Carthage.Common
-import           Debug.Trace
 
 newtype Location = Location { unLocation :: String }
                    deriving (Eq, Show, Ord)

--- a/src/Data/Romefile.hs
+++ b/src/Data/Romefile.hs
@@ -37,7 +37,6 @@ import qualified Data.HashMap.Strict          as M
 import           Data.Ini                     as INI
 import           Data.List                    (nub)
 import           Data.Maybe
-import           Data.Monoid
 import qualified Data.Text                    as T
 import           Data.Yaml
 import           GHC.Generics

--- a/src/Data/Romefile.hs
+++ b/src/Data/Romefile.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 
 

--- a/src/Text/Parsec/Utils.hs
+++ b/src/Text/Parsec/Utils.hs
@@ -9,7 +9,6 @@ module Text.Parsec.Utils
 
 import           Control.Applicative ((<|>))
 import qualified Text.Parsec         as Parsec
-import Data.Functor.Identity
 
 
 


### PR DESCRIPTION
Fixes/silences all compiler warnings.

Also turns on `-Werror` (treat warnings as errors) - but this is debatable. Could become annoying during development, but a dev could disable it temporarily during development, and not commit it, might lead to more build failures though.