### PR TITLE
Add cache prefix to remote framework upload path with engine

### DIFF
--- a/integration-tests/current-framework-named-engine-yml.bats
+++ b/integration-tests/current-framework-named-engine-yml.bats
@@ -221,3 +221,16 @@ teardown() {
   [ -d "Carthage/Build/watchOS/${FRAMEWORK_ARTIFACT_NAME}.framework.dSYM" ]
   [ -f "Carthage/Build/watchOS/${WATCHOS_ARMV7K_DWARF_UUID}.bcsymbolmap" ]
 }
+
+@test "rome list named artifacts for current framework with engine skipping local cache (dynamic, yaml)" {
+
+  # restore server cache
+  if [ -d "../../_server-cache_bkp" ]; then
+    echo "# Server cache restored" >&3
+    cp -R ../../_server-cache_bkp server-cache/
+  fi
+
+  run rome list --cache-prefix travis
+
+  [ "$status" -eq 0 ]
+}

--- a/integration-tests/engine.sh
+++ b/integration-tests/engine.sh
@@ -9,7 +9,6 @@ STORAGE_DIR="server-cache"
 if [ "$ACTION" == "upload" ]; then
   LOCAL_PATH="$2"
   REMOTE_PATH="$3"
-  # POST request to upload file to remote path
   # create directory structure if it doesn't exist yet
   mkdir -p $STORAGE_DIR/$(dirname $REMOTE_PATH)
   # fake the upload of a file by just copying binary to the storage directory
@@ -28,8 +27,14 @@ elif [ "$ACTION" == "download" ]; then
 
 elif [ "$ACTION" == "list" ]; then
   REMOTE_PATH="$2"
+
+  # verify that the list command contains the cache prefix
+  if [[ ! "$REMOTE_PATH" =~ "travis" ]]; then
+    exit 1
+  fi
+
   # fake list command by just checking if file exists
-  if [ ! -f "$STORAGE_DIR/$REMOTE_PATH" ]; then
+  if [[ ! -f "$STORAGE_DIR/$REMOTE_PATH" ]]; then
     exit 1
   fi
   

--- a/src/Engine/Probing.hs
+++ b/src/Engine/Probing.hs
@@ -9,21 +9,23 @@ import           Data.Romefile                (_frameworkPlatforms)
 import           Types                        hiding (version)
 import           Utils
 import qualified Turtle
+import           System.FilePath              ((</>))
 
 
 -- | Probes a `FilePath` to check if each `FrameworkVersion` exists for each `TargetPlatform`
 probeEngineForFrameworks
   :: MonadIO m
   => FilePath -- ^ The `FilePath` to the engine
+  -> CachePrefix -- ^ The top level directory prefix.
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> [FrameworkVersion] -- ^ A list of `FrameworkVersion` to probe for.
   -> [TargetPlatform] -- ^ A list target platforms restricting the scope of this action.
   -> m [FrameworkAvailability]
-probeEngineForFrameworks lCacheDir reverseRomeMap frameworkVersions
+probeEngineForFrameworks lCacheDir cachePrefix reverseRomeMap frameworkVersions
   = sequence . probeForEachFramework
  where
   probeForEachFramework = mapM
-    (probeEngineForFramework lCacheDir reverseRomeMap)
+    (probeEngineForFramework lCacheDir cachePrefix reverseRomeMap)
     frameworkVersions
 
 
@@ -31,15 +33,17 @@ probeEngineForFrameworks lCacheDir reverseRomeMap frameworkVersions
 probeEngineForFramework
   :: MonadIO m
   => FilePath -- ^ The `FilePath` to the engine
+  -> CachePrefix -- ^ The top level directory prefix.
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` to probe for.
   -> [TargetPlatform] -- ^ A list target platforms restricting the scope of this action.
   -> m FrameworkAvailability
-probeEngineForFramework lCacheDir reverseRomeMap frameworkVersion platforms
+probeEngineForFramework lCacheDir cachePrefix reverseRomeMap frameworkVersion platforms
   = fmap (FrameworkAvailability frameworkVersion) probeForEachPlatform
  where
   probeForEachPlatform = mapM
     (probeEngineForFrameworkOnPlatform lCacheDir
+                                       cachePrefix
                                        reverseRomeMap
                                        frameworkVersion
    )
@@ -50,16 +54,17 @@ probeEngineForFramework lCacheDir reverseRomeMap frameworkVersion platforms
 probeEngineForFrameworkOnPlatform
   :: MonadIO m
   => FilePath -- ^ The `FilePath` to the engine
+  -> CachePrefix -- ^ The top level directory prefix.
   -> InvertedRepositoryMap -- ^ The map used to resolve `FrameworkName`s to `GitRepoName`s.
   -> FrameworkVersion -- ^ The `FrameworkVersion` to probe for.
   -> TargetPlatform -- ^ A target platforms restricting the scope of this action.
   -> m PlatformAvailability
-probeEngineForFrameworkOnPlatform enginePath reverseRomeMap (FrameworkVersion fwn version) platform
+probeEngineForFrameworkOnPlatform enginePath (CachePrefix prefix) reverseRomeMap (FrameworkVersion fwn version) platform
   = do
     let cmd = Turtle.fromString enginePath
     exitCode <- Turtle.proc
         cmd
-        ["list", Turtle.fromString remoteFrameworkUploadPath]
+        ["list", Turtle.fromString (prefix </> remoteFrameworkUploadPath)]
         (return $ Turtle.unsafeTextToLine "")
     case exitCode of
         -- If engine exits with success, we assume the framework exists.

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -530,7 +530,9 @@ getProjectAvailabilityFromCaches Nothing (Just lCacheDir) Nothing reverseReposit
 
 getProjectAvailabilityFromCaches Nothing _ (Just ePath) reverseRepositoryMap frameworkVersions platforms
   = do
+    (cachePrefix, _, _) <- ask
     availabilities <- probeEngineForFrameworks ePath
+                                               cachePrefix
                                                reverseRepositoryMap
                                                frameworkVersions
                                                platforms


### PR DESCRIPTION
This fixes an issue where if a `cachePrefix` was specified and the Romefile was set up to use an engine, the path passed to the engine would not be prefixed with `cachePrefix`.

- Before the patch:
`$ rome list --cache-prefix MyAmazingPrefix` passed `Alamofire/iOS/Alamofire.framework-4.8.2.zip` to the engine script.
- After the patch:
`$ rome list --cache-prefix MyAmazingPrefix` passes `MyAmazingPrefix /Alamofire/iOS/Alamofire.framework-4.8.2.zip` to the engine script.